### PR TITLE
fix: typo causing error

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -8,7 +8,7 @@ RegisterServerEvent("garbage:createGroupJob", function(groupID)
 
         local jobID = #Jobs
 
-        local TruckSpawn = Config.TruckSpawns[math.random(1. #Config.TruckSpawns)]
+        local TruckSpawn = Config.TruckSpawns[math.random(#Config.TruckSpawns)]
 
         local car = CreateVehicle("trash", TruckSpawn.x, TruckSpawn.y, TruckSpawn.z, TruckSpawn.w, true, true)
         while not DoesEntityExist(car) do


### PR DESCRIPTION
Keep in mind when you are doing a random number between 1-x you dont need to add 1 as the minimum number just add a maximum